### PR TITLE
[PKG-2640] python-multipart 0.0.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_without_merge: true
+
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,30 +1,33 @@
 {% set name = "python-multipart" %}
-{% set version = "0.0.5" %}
+{% set version = "0.0.6" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43
+  url: https://pypi.io/packages/source/{{ name[0] }}/python_multipart/python_multipart-{{ version }}.tar.gz
+  sha256: e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
+    - hatchling
     - python
     - pip
   run:
     - python
-    - six >=1.4.0
 
 test:
   imports:
     - multipart
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/andrew-d/python-multipart
@@ -36,7 +39,7 @@ about:
     python-multipart is an Apache2 licensed streaming multipart parser for Python.
     It's still under some development, but test coverage is currently 100%.
     Documentation is available [here](http://andrew-d.github.io/python-multipart/).
-  doc_url: http://andrew-d.github.io/python-multipart/
+  doc_url: https://andrew-d.github.io/python-multipart/
   dev_url: https://github.com/andrew-d/python-multipart
 
 extra:


### PR DESCRIPTION
Changelog: https://github.com/andrew-d/python-multipart/blob/0.0.6/CHANGELOG.md
Diff: https://github.com/andrew-d/python-multipart/compare/0.0.5...0.0.6
License: https://github.com/andrew-d/python-multipart/blob/0.0.6/LICENSE.txt
Requirements: https://github.com/andrew-d/python-multipart/blob/0.0.6/pyproject.toml

Actions:
1. Clean up the recipe:
- Remove `noarch` python
- Add the flags `--no-build-isolation -vv` to `script`
- Add missing `hatchling` to `host`
- Add `pip check`
2. Fix source/url
3. Remove `six` from `run`
4. Fix `doc_url`


Notes:
- `stralette-full 0.27.0` requires `python-multipart`, see https://github.com/AnacondaRecipes/starlette-feedstock/pull/2/files