### PR TITLE
python-multipart 0.0.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-multipart" %}
-{% set version = "0.0.6" %}
+{% set version = "0.0.9" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/python_multipart/python_multipart-{{ version }}.tar.gz
-  sha256: e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132
+  sha256: 03f54688c663f1b7977105f021043b0793151e4cb1c1a9d4a11fc13d622c4026
 
 build:
   number: 0
@@ -28,13 +28,17 @@ test:
     - pip
   commands:
     - pip check
+  downstreams:
+    - starlette-full
+    - lightning
+    - lightning-cloud
 
 about:
   home: https://github.com/andrew-d/python-multipart
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
-  summary: 'A streaming multipart parser for Python.'
+  summary: A streaming multipart parser for Python.
   description: |
     python-multipart is an Apache2 licensed streaming multipart parser for Python.
     It's still under some development, but test coverage is currently 100%.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,9 @@ test:
     - pip check
   downstreams:
     - starlette-full
-    - lightning
+    # Skip py<312 on win because of incompatible pydantic version:
+    # "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
+    - lightning  # [py<312 and win]
     - lightning-cloud
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,17 +34,15 @@ test:
     - lightning-cloud
 
 about:
-  home: https://github.com/andrew-d/python-multipart
+  home: https://github.com/Kludex/python-multipart
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
   summary: A streaming multipart parser for Python.
   description: |
     python-multipart is an Apache2 licensed streaming multipart parser for Python.
-    It's still under some development, but test coverage is currently 100%.
-    Documentation is available [here](http://andrew-d.github.io/python-multipart/).
-  doc_url: https://andrew-d.github.io/python-multipart/
-  dev_url: https://github.com/andrew-d/python-multipart
+  doc_url: https://kludex.github.io/python-multipart/
+  dev_url: https://github.com/Kludex/python-multipart
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,12 @@ test:
     - pip
   commands:
     - pip check
-  downstreams:
-    - starlette-full
-    # Skip py<312 on win because of incompatible pydantic version:
-    # "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
-    - lightning  # [py<312 and win]
-    - lightning-cloud
+  # downstreams:
+  #   - starlette-full
+  #   # Skip py<312 because of incompatible pydantic version:
+  #   # "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
+  #   - lightning  # [py<312]
+  #   - lightning-cloud
 
 about:
   home: https://github.com/Kludex/python-multipart


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5372](https://anaconda.atlassian.net/browse/PKG-5372) 
- [Upstream repository](https://github.com/Kludex/python-multipart/tree/0.0.9)
- Changelog: https://github.com/Kludex/python-multipart/blob/0.0.9/CHANGELOG.md
- Requirements: https://github.com/Kludex/python-multipart/blob/0.0.9/pyproject.toml

### Explanation of changes:

- Update home, dev & doc urls, description

### Notes:

- To address CVE-2024-24762 with a score of 7.5
- I've tested downstream packages `starlette-full`, `lightning`, and `lightning-cloud`. `lightning` fails for **py>=312** because of an incompatible `pydantic` version but it's a known issue we plan to work with

[PKG-5372]: https://anaconda.atlassian.net/browse/PKG-5372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ