### PR TITLE
python-multipart 0.0.20

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-multipart" %}
-{% set version = "0.0.9" %}
+{% set version = "0.0.20" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/python_multipart/python_multipart-{{ version }}.tar.gz
-  sha256: 03f54688c663f1b7977105f021043b0793151e4cb1c1a9d4a11fc13d622c4026
+  sha256: 8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,6 @@ test:
     - pip
   commands:
     - pip check
-  # downstreams:
-  #   - starlette-full
-  #   # Skip py<312 because of incompatible pydantic version:
-  #   # "TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'"
-  #   - lightning  # [py<312]
-  #   - lightning-cloud
 
 about:
   home: https://github.com/Kludex/python-multipart


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-7634](https://anaconda.atlassian.net/browse/PKG-7634)
- [Upstream repository](https://github.com/Kludex/python-multipart/tree/0.0.20)
- [Upstream changelog/diff](https://github.com/Kludex/python-multipart/blob/0.0.20/CHANGELOG.md)

### Explanation of changes:

- Update version to 0.0.20
- Clean up old test commands
- build for python 3.13

[PKG-7634]: https://anaconda.atlassian.net/browse/PKG-7634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ